### PR TITLE
initial abs recipe

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,10 @@
+aggregate_check: false
+channels:
+  - services
+  - sfe1ed40
+upload_channels:
+  - services
+  - sfe1ed40
+build_parameters:
+  - "--no-error-overlinking"
+  - "--no-error-overdepending"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ test:
   requires:
     - pip
     - numba
+    - numpy <1.22
   imports:
     - PyNomaly
     - PyNomaly.loop

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,11 +31,11 @@ requirements:
 test:
   requires:
     - pip
-    - numba
-    - numpy <1.22
+    - numba         # [not s390x]
+    - numpy <1.22   # [not s390x]
   imports:
     - PyNomaly
-    - PyNomaly.loop
+    - PyNomaly.loop # [not s390x]
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "pynomaly" %}
 {% set version = "0.3.3" %}
+{% set sha256 = "8bf89d904eccccde581fc27d90295bb4a7e9de6cc3a2dd726fdd79df8678e0bd" %}
 
 package:
   name: {{ name|lower }}
@@ -7,35 +8,50 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/PyNomaly-{{ version }}.tar.gz
-  sha256: 8bf89d904eccccde581fc27d90295bb4a7e9de6cc3a2dd726fdd79df8678e0bd
+  sha256: {{ sha256 }}
 
 build:
-  noarch: python
+  # noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
 
 requirements:
   host:
+    - python
     - pip
-    - python >=3.7
+    - setuptools
+    - wheel
   run:
+    - python
+    - python-utils >=2.3.0
     - numpy
-    - python >=3.7
-    - python-utils
+  run_constrained:
+    - numba >=0.45.1
 
 test:
-  imports:
-    - PyNomaly
-  commands:
-    - pip check
   requires:
     - pip
+    - numba
+  imports:
+    - PyNomaly
+    - PyNomaly.loop
+  commands:
+    - pip check
 
 about:
   home: https://github.com/vc1492a/PyNomaly
   summary: 'A Python 3 implementation of LoOP: Local Outlier Probabilities.'
+  description: |
+    PyNomaly is a Python 3 implementation of LoOP (Local Outlier Probabilities).
+    LoOP is a local density based outlier detection method by Kriegel, Kröger,
+    Schubert, and Zimek which provides outlier scores in the range of [0,1] that
+    are directly interpretable as the probability of a sample being an outlier.
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE.txt
+  doc_url: https://github.com/vc1492a/PyNomaly/blob/main/readme.md
+  doc_source_url: https://github.com/vc1492a/PyNomaly/blob/main/readme.md
+  dev_url: https://github.com/vc1492a/PyNomaly
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
[NOTE: not yet a defaults build]

- moved sha256 to top
- added setuptools, wheel dependencies
- added optional numba dependency and test import
- added version bound on python-utils
- fleshed out metadata