### PR TITLE
[PKG-2690] pynomaly 0.3.3 - Rebuild for py311 support :snowflake: 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,10 +1,2 @@
-aggregate_check: false
-channels:
-  - services
-  - sfe1ed40
 upload_channels:
-  - services
   - sfe1ed40
-build_parameters:
-  - "--no-error-overlinking"
-  - "--no-error-overdepending"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "pynomaly" %}
 {% set version = "0.3.3" %}
-{% set sha256 = "8bf89d904eccccde581fc27d90295bb4a7e9de6cc3a2dd726fdd79df8678e0bd" %}
 
 package:
   name: {{ name|lower }}
@@ -8,12 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/PyNomaly-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 8bf89d904eccccde581fc27d90295bb4a7e9de6cc3a2dd726fdd79df8678e0bd
 
 build:
-  # noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
@@ -23,19 +21,19 @@ requirements:
     - wheel
   run:
     - python
-    - python-utils >=2.3.0
     - numpy
+    - python-utils >=2.3.0
   run_constrained:
     - numba >=0.45.1
 
 test:
-  requires:
-    - pip
-    - numba         # [not s390x]
-    - numpy <1.22   # [not s390x]
   imports:
     - PyNomaly
     - PyNomaly.loop # [not s390x]
+  requires:
+    - pip
+    - numba         # [not s390x]
+    - numpy         # [not s390x]
   commands:
     - pip check
 
@@ -51,7 +49,6 @@ about:
   license_family: Apache
   license_file: LICENSE.txt
   doc_url: https://github.com/vc1492a/PyNomaly/blob/main/readme.md
-  doc_source_url: https://github.com/vc1492a/PyNomaly/blob/main/readme.md
   dev_url: https://github.com/vc1492a/PyNomaly
 
 extra:


### PR DESCRIPTION
See the previous PR https://github.com/AnacondaRecipes/pynomaly-feedstock/pull/1/files

Changelog: https://github.com/vc1492a/PyNomaly/blob/0.3.3/changelog.md
License: https://github.com/vc1492a/PyNomaly/blob/0.3.3/LICENSE.txt
Requirements: 
- https://github.com/vc1492a/PyNomaly/blob/0.3.3/requirements.txt
- https://github.com/vc1492a/PyNomaly/blob/0.3.3/setup.py

Actions:
1. Update `abs.yaml`
2. Increase the build number to `1`
3. Add `--no-deps --no-build-isolation` to `script`
4. Fix numpy in test/requires
5. Remove `doc_source_url`